### PR TITLE
feat: Add Dockerfile for Python application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Use a minimal base image with Python
+FROM python:3.10-slim
+
+# Set environment variables for Python
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install OS dependencies (Tesseract, Poppler for pdfplumber, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    poppler-utils \
+    build-essential \
+    libglib2.0-0 \
+    libsm6 \
+    libxrender1 \
+    libxext6 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the app source code
+COPY . /app
+
+# Install Python dependencies
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Expose port (Coolify sets PORT env var, but hardcode for local use)
+ENV PORT=3000
+EXPOSE 3000
+
+# Run the application
+CMD ["python", "app.py"]
+


### PR DESCRIPTION
This commit adds a Dockerfile to containerize the Python application. The
key changes include:

- Use a minimal Python 3.10 base image
- Set environment variables for Python to improve performance
- Install OS dependencies required by the application, such as Tesseract
  OCR and Poppler for PDF processing
- Set the working directory to `/app` and copy the application source code
- Install Python dependencies using `pip`
- Expose port 3000 for the application
- Define the entry point to run the `app.py` script

These changes will allow the application to be easily deployed and run
in a containerized environment.